### PR TITLE
Small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Not control         1164572          0   0.0000%   0.0000
 ## Sample Output if using python script for all the traces:
 
 ```
-python trace_exec_training_list.py  --trace_dir sample_traces/ --results_dir  sample_results
+python scripts/trace_exec_training_list.py  --trace_dir sample_traces/ --results_dir  sample_results
 Got 2 traces
 Begin processing run:fp/sample_fp_trace
 Begin processing run:int/sample_int_trace

--- a/lib/cbp.cc
+++ b/lib/cbp.cc
@@ -322,5 +322,6 @@ int main(int argc, char ** argv)
   }
 
   endPredictor();
+  endCondDirPredictor();
   sim->output();
 }


### PR DESCRIPTION
While looking into the repo I came across minor bugs:
1. `endCondDirPredictor()` is not called in the simulator
2. the `trace_exec_training_list.py` was move the the `script` folder