### PR TITLE
Fix to use delete[] instead of delete

### DIFF
--- a/lib/resource_schedule.cc
+++ b/lib/resource_schedule.cc
@@ -59,7 +59,7 @@ void resource_schedule::resize(uint64_t new_depth) {
    for (i = old_depth; i < depth; i++)
       sched[i] = 0;
 
-   delete old;
+   delete[] old;
 }
 
 uint64_t resource_schedule::schedule(uint64_t start_cycle, uint64_t max_delta) 


### PR DESCRIPTION
GCC's address sanitizer finds a mismatch between the allocate-deallocate operators (operator new [] vs operator delete).
This misuse sometimes causes a segmentation fault (and I encountered it...).