### PR TITLE
Fix storage budget calculation for TAGE-SC-L

### DIFF
--- a/cbp2016_tage_sc_l.h
+++ b/cbp2016_tage_sc_l.h
@@ -369,7 +369,7 @@ int predictorsize ()
 #endif
 
     inter += WIDTHRES;
-    inter = WIDTHRESP * ((1 << LOGSIZEUP)); //the update threshold counters
+    inter += WIDTHRESP * ((1 << LOGSIZEUP)); //the update threshold counters
     inter += 3 * EWIDTH * (1 << LOGSIZEUPS);    // the extra weight of the partial sums
     inter += (PERCWIDTH) * 3 * (1 << (LOGBIAS));
 


### PR DESCRIPTION
I found a bug in `predictorsize()`. The storage budget was underestimated by 12 bits. This PR fixes this.